### PR TITLE
fix CSS ::selection applied to entire page

### DIFF
--- a/src/multipicker.css
+++ b/src/multipicker.css
@@ -1,7 +1,7 @@
-::selection {
+.checklist::selection {
   	background: none;
 }
-::-moz-selection {
+.checklist::-moz-selection {
   	background: none;
 }
 .checklist {


### PR DESCRIPTION
The first CSS rule is a bit too aggressive: it's removing the selection background from every element on the page! :)
Limited to .checklist elements.

repro:
- open the plugin [official website](http://styopdev.github.io/multiPicker/)
- try to select some text (i.e. from a code example)

expected: 
- the code is selected and highlighted

actual:
- the code is selected, but there is no visual indication